### PR TITLE
add en_AU and en_GB translations

### DIFF
--- a/src/main/resources/assets/georenouveau/lang/en_au.json
+++ b/src/main/resources/assets/georenouveau/lang/en_au.json
@@ -1,0 +1,6 @@
+{
+  "item.georenouveau.aluminum_geore_dowsing_rod": "Aluminium GeOre Dowsing Rod",
+  "item.georenouveau.aluminum_geore_golem_charm": "Aluminium GeOre Golem Charm",
+  "tooltip.geore_nouveau.aluminum_charm": "Obtained by performing the Ritual of Awakening near Budding Aluminium Geore",
+  "tooltip.geore_nouveau.aluminum_dowsing_rod": "Grants Magic Find and Scrying on use, causing magical creatures to glow and Aluminium Geore to be revealed through blocks. Can be used on Imbuement Chamber and Enchanting Apparatus to highlight linked pedestals."
+}

--- a/src/main/resources/assets/georenouveau/lang/en_gb.json
+++ b/src/main/resources/assets/georenouveau/lang/en_gb.json
@@ -1,0 +1,6 @@
+{
+  "item.georenouveau.aluminum_geore_dowsing_rod": "Aluminium GeOre Dowsing Rod",
+  "item.georenouveau.aluminum_geore_golem_charm": "Aluminium GeOre Golem Charm",
+  "tooltip.geore_nouveau.aluminum_charm": "Obtained by performing the Ritual of Awakening near Budding Aluminium Geore",
+  "tooltip.geore_nouveau.aluminum_dowsing_rod": "Grants Magic Find and Scrying on use, causing magical creatures to glow and Aluminium Geore to be revealed through blocks. Can be used on Imbuement Chamber and Enchanting Apparatus to highlight linked pedestals."
+}


### PR DESCRIPTION
Change "Aluminum" to "Aluminium" in Australian and British locales.